### PR TITLE
[20기 안정현] Modify: useState 및 useEffect 훅 대신 변수 선언을 통해 로그인 여부 확인하는 로직으로 변경 

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 import TopBanner from './TopBanner';
 import { flexSet } from '../../styles/Variable';
 
-function Nav(props) {
+function Nav() {
   const location = useLocation();
+  const isLoggedIn = localStorage.getItem('access_token');
 
   return (
     <>
@@ -36,7 +37,9 @@ function Nav(props) {
               <FaShoppingCartIcon className="fas fa-shopping-cart" />
             </CartIconWrapper>
             <LoginAndSignUpWrapper>
-              <GoToLoginPageLink to="/login">로그인</GoToLoginPageLink>
+              <GoToLoginPageLink to="/login">
+                {isLoggedIn ? '로그아웃' : '로그인'}
+              </GoToLoginPageLink>
               <GoToSignUpPageLink to="/signup">회원가입</GoToSignUpPageLink>
             </LoginAndSignUpWrapper>
             <WritingMenuWrapper>


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
- useState 및 useEffect 훅 대신 변수 선언을 통해 로그인 여부 확인하는 로직으로 변경 
  * 로그인이 성공하여  access token이 localStorage 에 있는 경우, nav 의 '로그인'을 '로그아웃' 으로 변경하는 로직
		 
## 수정 사항들 자세한 내용
- '소셜 로그인' 에 대해서는 아직 프론트와 백엔드 간에 통신이 진행되지 않아 
  * 우선은 '일반 로그인' 에 대해서만 'access_token' key 값을 받았는지 여부로 로직 구현

## 기타 질문 및 특이 사항
- (1) 일반로그인 및 (2) 소셜로그인 2가지 방법을 다 사용하게 될 경우
  * isLoggedIn 변수 우측에 || 연산자를 이용해서 '일반로그인 access_token key || 소셜로그인 access_token key' 이렇게 로직을 구현하면 되는지 문의드립니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
